### PR TITLE
php5-ssh2 dep and max child for fpm

### DIFF
--- a/doc/fr_FR/other.asciidoc
+++ b/doc/fr_FR/other.asciidoc
@@ -24,7 +24,7 @@ Les étapes suivantes décrivent comment installer un serveur LNMP (Linux Nginx 
 mkdir -p /var/www/html/log
 apt-get -y install ntp ca-certificates unzip curl sudo
 apt-get -y install apache2 php5 mysql-client mysql-server libapache2-mod-php5 apache2-mpm-prefork
-apt-get -y install php5-cli php5-common php5-curl php5-json php5-mysql php5-gd
+apt-get -y install php5-cli php5-common php5-curl php5-json php5-mysql php5-gd php5-ssh2
 wget https://raw.githubusercontent.com/jeedom/core/stable/install/apache_security -O /etc/apache2/conf-available/security.conf
 rm /etc/apache2/conf-enabled/security.conf
 ln -s /etc/apache2/conf-available/security.conf /etc/apache2/conf-enabled/
@@ -39,7 +39,7 @@ rm /var/www/html/index.html
 ----
 apt-get -y install mysql-client mysql-server
 apt-get -y install nginx-common nginx-full ntp ca-certificates unzip curl sudo
-apt-get -y install php5-cli php5-common php5-curl php5-fpm php5-json php5-mysql php5-gd
+apt-get -y install php5-cli php5-common php5-curl php5-fpm php5-json php5-mysql php5-gd php5-ssh2
 ----
 
 [IMPORTANT]
@@ -53,7 +53,6 @@ sed -i 's/max_execution_time = 30/max_execution_time = 600/g' /etc/php5/fpm/php.
 sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 1G/g' /etc/php5/fpm/php.ini
 sed -i 's/post_max_size = 8M/post_max_size = 1G/g' /etc/php5/fpm/php.ini
 sed -i 's/expose_php = On/expose_php = Off/g' /etc/php5/fpm/php.ini
-sed -i 's/pm.max_children = 5/pm.max_children = 20/g' /etc/php5/fpm/pool.d/www.conf
 rm /etc/nginx/sites-available/default
 rm /etc/nginx/sites-enabled/default
 wget https://raw.githubusercontent.com/jeedom/core/stable/install/nginx_default -O /etc/nginx/sites-available/default


### PR DESCRIPTION
Add php5-ssh2 as a dependencies in apache and nginx installation
Remove the max pm children line modification in php fpm as it's too high for small configurations